### PR TITLE
Handling of multiple files with same name in a project.

### DIFF
--- a/autofolding/src/main/java/codesum/lm/main/CodeUtils.java
+++ b/autofolding/src/main/java/codesum/lm/main/CodeUtils.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
@@ -59,7 +58,8 @@ public class CodeUtils {
 				count++;
 
 				String originalPath = file.getPath();
-				String outPutRelativePath = StringUtils.removeStart(originalPath, set.projectsFolder + curProj + "/");
+				String outPutRelativePath = StringUtils.removeStart(
+						originalPath, set.projectsFolder + curProj + "/");
 				String outputFilePath = outFolder + outPutRelativePath;
 
 				// Write out file with one token line per foldable node
@@ -82,6 +82,9 @@ public class CodeUtils {
 		}
 	}
 
+	/**
+	 * Get nodewise token list for a file.
+	 */
 	public static List<String> getTokenList(File file, Settings set) {
 		// Create folded tree and populate nodes with term vectors
 		final TreeCreatorVisitor tcv = new TreeCreatorVisitor();
@@ -95,15 +98,7 @@ public class CodeUtils {
 			for (final String token : tcv.getIDTokens().get(nodeID)){
 				sb.append(token + " ");
 			}
-				//out.print(token + " ");
-			//out.print("\n");
 			tokenList.add(sb.toString());
-		}
-		
-		if(file.getPath().contains("WordCountSetup.java")){
-			System.out.println("At file : " + file.getPath());
-			for(String line: tokenList)
-				System.out.println(line);
 		}
 		
 		return tokenList;
@@ -256,6 +251,11 @@ public class CodeUtils {
 
 	public static ArrayList<Integer> range(final int start, final int stop) {
 		return range(start, stop, 1);
+	}
+	
+	public static String getRelativePath(File file, String relativeTo){
+		String prefix = StringUtils.substringBefore(file.getPath(), relativeTo);
+		return StringUtils.removeStart(file.getPath(), prefix);
 	}
 
 }

--- a/autofolding/src/main/java/codesum/lm/main/FoldableTree.java
+++ b/autofolding/src/main/java/codesum/lm/main/FoldableTree.java
@@ -412,8 +412,10 @@ public class FoldableTree {
 				unfoldedNodeIDs.add(fn.nodeID);
 
 				// Get specified profit
-				final String curFile = FilenameUtils
-						.getBaseName(file.getName());
+				final String curFile = CodeUtils.getRelativePath(file,
+						set.curProj);
+				// final String curFile =
+				// FilenameUtils.getBaseName(file.getName());
 				if (set.profitType.matches("KLDiv.*"))
 					profit = -1
 							* sampler.getKLDiv(set.profitType,

--- a/autofolding/src/main/java/codesum/lm/topicsum/Cluster.java
+++ b/autofolding/src/main/java/codesum/lm/topicsum/Cluster.java
@@ -2,6 +2,9 @@ package codesum.lm.topicsum;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
 
 import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
@@ -20,27 +23,40 @@ public class Cluster implements Serializable {
 		clusterLoc = f;
 		ndocs = 0;
 
-		docs = new Document[clusterLoc.listFiles().length];
+		docs = new Document[getFilesInCluster(null).size()];
 
 		getDocs(alphabet);
 	}
 
 	private void getDocs(final Tokens alphabet) {
+		final List<File> files = getFilesInCluster(null);
+		
+		int i=0;
+		int total = files.size();
+		//for (int i = 0; i < clusterLoc.listFiles().length; i++) {
 
-		for (int i = 0; i < clusterLoc.listFiles().length; i++) {
-
+		for(File file : files){
 			if (i % 100 == 0)
-				System.out.println("At file " + i + " of "
-						+ clusterLoc.listFiles().length);
+				System.out.println("At file " + i + " of " + total);
 
 			// if the file is not a hidden file (shouldn't need this)
-			if (clusterLoc.listFiles()[i].getName().charAt(0) != '.'
-					&& clusterLoc.listFiles()[i].getName().charAt(
-							clusterLoc.listFiles()[i].getName().length() - 1) != '~') {
-				docs[i] = new Document(clusterLoc.listFiles()[i], alphabet);
+			if (file.getName().charAt(0) != '.'
+					&& file.getName().charAt(
+							file.getName().length() - 1) != '~') {
+				docs[i] = new Document(file, alphabet);
 				ndocs++;
 			}
+			i++;
 		}
+	}
+
+	private List<File> getFilesInCluster(String[] extns) {
+		if(extns == null){
+			extns = new String[] { "java" };
+		}
+		// Get all files with extn extension in the cluster
+		final List<File> files = (List<File>) FileUtils.listFiles(clusterLoc, extns, true);
+		return files;
 	}
 
 	public int ndocs() {
@@ -58,7 +74,7 @@ public class Cluster implements Serializable {
 	public int getIndexDoc(final String fileName) {
 
 		for (int di = 0; di < ndocs; di++) {
-			if ((docs[di].getName()).equals(fileName))
+			if ((docs[di].getDocLoc().getPath().contains(fileName)))
 				return di;
 		}
 		return -1;

--- a/autofolding/src/main/java/codesum/lm/topicsum/Cluster.java
+++ b/autofolding/src/main/java/codesum/lm/topicsum/Cluster.java
@@ -71,10 +71,12 @@ public class Cluster implements Serializable {
 		return clusterLoc.getName();
 	}
 
-	public int getIndexDoc(final String fileName) {
+	public int getIndexDoc(final String filePath) {
 
 		for (int di = 0; di < ndocs; di++) {
-			if ((docs[di].getDocLoc().getPath().contains(fileName)))
+			//Just check if the relative filepath of a java file
+			// is a subset of the token document location. 
+			if ((docs[di].getDocLoc().getPath().contains(filePath)))
 				return di;
 		}
 		return -1;

--- a/autofolding/src/main/java/codesum/lm/tui/ListSalientFiles.java
+++ b/autofolding/src/main/java/codesum/lm/tui/ListSalientFiles.java
@@ -103,7 +103,7 @@ public class ListSalientFiles {
 				lineNumbers.add(i);
 			}
 			
-			final String curFile = StringUtils.removeStart(file.getPath(), workingDir + project + "/");
+			final String curFile = CodeUtils.getRelativePath(file, project);
 			
 			Double klScore = -1
 					* sampler.getKLDiv("KLDivProj",

--- a/autofolding/src/main/java/codesum/lm/tui/ListSalientFiles.java
+++ b/autofolding/src/main/java/codesum/lm/tui/ListSalientFiles.java
@@ -1,0 +1,168 @@
+package codesum.lm.tui;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+
+import codesum.lm.main.CodeUtils;
+import codesum.lm.main.Settings;
+import codesum.lm.topicsum.GibbsSampler;
+import codesum.lm.tui.FoldSourceFile.checkBackoffTopic;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+
+public class ListSalientFiles {
+
+	/** Command line parameters */
+	public static class Parameters {
+
+		@Parameter(names = { "-d", "--dir" }, description = "Directory where projects are located", required = true)
+		String workingDir;
+
+		@Parameter(names = { "-p", "--project" }, description = "Project to summarize", required = true)
+		String project;
+
+		@Parameter(names = { "-c", "--ratio" }, description = "Desired compression percentage in term of (important file*100/all files)", required = true)
+		int compressionRatio;
+
+		@Parameter(names = { "-b", "--backoffTopic" }, description = "Background topic to back off to (0-2)", validateWith = checkBackoffTopic.class)
+		int backoffTopic = 2;
+
+		@Parameter(names = { "-o", "--outFile" }, description = "Where to save salient files")
+		File outFile = null;
+		
+		@Parameter(names = { "-i", "--ignoreTests" }, description = "Whether to ignore test classes")
+		Boolean ignoreTestFiles = true;
+		
+		@Parameter(names = { "-s", "--samplerLoc" }, description = "Where to locate the serialized sampler")
+		String samplerLoc;
+	}
+	
+	public static void main(final String[] args) {
+
+		final Parameters params = new Parameters();
+		final JCommander jc = new JCommander(params);
+
+		try {
+			jc.parse(args);
+			listSalientFiles(params.workingDir, params.project,
+					params.compressionRatio, params.backoffTopic,
+					params.outFile, params.samplerLoc, params.ignoreTestFiles);
+		} catch (final ParameterException e) {
+			System.out.println(e.getMessage());
+			jc.usage();
+		}
+
+	}
+
+	private static void listSalientFiles(String workingDir, String project,
+			int compressionRatio, int backoffTopic, File outFolder, String samplerLoc, Boolean ignoreTestFiles) {
+		
+		final Settings set = new Settings();
+
+		// Main code folder settings
+		set.backoffTopicID = backoffTopic;
+		set.curProj = project;
+		set.compressionRatio = compressionRatio;
+
+		// Load Topic Model
+		System.out.println("Deserializing the model...");
+		final GibbsSampler sampler = GibbsSampler.readCorpus(samplerLoc
+				+ "TopicSum/Source/SamplerState.ser");
+		
+		// Get all java files in source folder
+		final List<File> files = (List<File>) FileUtils.listFiles(new File(
+				workingDir + project + "/"),
+				new String[] { "java" }, true);
+		
+		int count = 0;
+		
+		List<FileScore> fileScores = new ArrayList<ListSalientFiles.FileScore>();
+		for (final File file : files) {
+			
+			// Ignore empty files
+			if (file.length() == 0)
+				continue;
+
+			if (count % 50 == 0)
+				System.out.println("At file " + count + " of "
+						+ files.size());
+			count++;
+			
+			List<String> lines = CodeUtils.getTokenList(file, set);
+			
+			List<Integer> lineNumbers = new ArrayList<Integer>();
+			for(int i=0; i < lines.size(); i++){
+				lineNumbers.add(i);
+			}
+			
+			final String curFile = StringUtils.removeStart(file.getPath(), workingDir + project + "/");
+			
+			Double klScore = -1
+					* sampler.getKLDiv("KLDivProj",
+							set.backoffTopicID, set.curProj, curFile,
+							lineNumbers);
+
+			fileScores.add(new FileScore(file.getPath(), klScore));
+		}
+
+		if(ignoreTestFiles){
+			Iterator<FileScore> iter = fileScores.iterator();
+			while(iter.hasNext()){
+				String filePath = iter.next().filePath;
+				if(filePath.contains("test") || filePath.contains("Test")){
+					iter.remove();
+				}
+			}
+		}
+		
+		int desiredNumberOfFiles = fileScores.size() * compressionRatio/100;
+		System.out.println("===============================================================");
+		System.out.println("Listing salient files for project: " + project);
+		System.out.println("Total files: " + fileScores.size() + "\t" + " Reducing to: " + desiredNumberOfFiles);
+		System.out.println("===============================================================");
+		
+		Collections.sort(fileScores);
+		int i = 0;
+		for(i=0; i<desiredNumberOfFiles; i++){
+			System.out.println(fileScores.get(i).score + "\t" +  fileScores.get(i).filePath);
+		}
+		
+		System.out.println("\n \n===============================================================");
+		System.out.println("Next 20 important files :");
+		System.out.println("===============================================================");
+		
+		for(int j=0; i<fileScores.size() && j < 20; j++, i++){
+			System.out.println(fileScores.get(i).score + "\t" +  fileScores.get(i).filePath);
+		}
+		
+		
+		
+	}
+	
+	private static class FileScore implements Comparable<FileScore>{
+
+		String filePath;
+		Double score;
+		
+		public FileScore(String filePath, Double score) {
+			this.filePath = filePath;
+			this.score = score;
+		}
+		
+		@Override
+		public int compareTo(FileScore o) {
+			return o.score.compareTo(score);
+		}
+		
+	}
+
+
+}


### PR DESCRIPTION
Made following changes -
1. CodeUtils.java : added a method to get relative file path. Plus, storing the tokenized files in the same directory structure as they appear in projects.
2. FoldableTree.java : using relative path of a file instead of just its name to get the doc in a cluster.
3. Cluster.java: storing/searching files by path instead of just name.